### PR TITLE
Added jetty.xml

### DIFF
--- a/entando-sample/src/main/resources/archetype-resources/pom.xml
+++ b/entando-sample/src/main/resources/archetype-resources/pom.xml
@@ -422,6 +422,7 @@
                                     <directory>src/main/config</directory>
                                     <includes>
                                         <include>jetty-env.xml</include>
+                                        <include>jetty.xml</include>
                                     </includes>
                                     <filtering>true</filtering>
                                 </resource>
@@ -561,6 +562,7 @@
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>7.6.16.v20140903</version>
                 <configuration>
+                    <jettyXml>${project.build.directory}/jetty/jetty.xml</jettyXml>
                     <scanIntervalSeconds>5</scanIntervalSeconds>
                     <webAppSourceDirectory>${basedir}/src/main/webapp</webAppSourceDirectory>
                     <webApp>

--- a/entando-sample/src/main/resources/archetype-resources/src/main/config/jetty.xml
+++ b/entando-sample/src/main/resources/archetype-resources/src/main/config/jetty.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+	<Call name="addConnector">
+		<Arg>
+			<New class="org.eclipse.jetty.server.nio.SelectChannelConnector">
+				<Set name="port">${profile.application.baseurl.port}</Set>
+				<Set name="host">${profile.application.baseurl.hostname}</Set>
+				<Set name="maxIdleTime">300000</Set>
+				<Set name="Acceptors">4</Set>
+				<Set name="statsOn">false</Set>
+				<Set name="confidentialPort">8443</Set>
+			    <Set name="lowResourcesConnections">20000</Set>
+			    <Set name="lowResourcesMaxIdleTime">5000</Set>
+			</New>
+		</Arg>
+	</Call>
+
+    <Set name="handler">
+        <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+            <Set name="handlers">
+                <Array type="org.eclipse.jetty.server.Handler">
+                    <Item>
+                        <New id="RequestLog" class="org.eclipse.jetty.server.handler.RequestLogHandler"/>
+                    </Item>
+                </Array>
+            </Set>
+        </New>
+    </Set>
+
+    <Ref id="RequestLog">
+        <Set name="requestLog">
+            <New id="RequestLogImpl" class="org.eclipse.jetty.server.NCSARequestLog">
+            <Set name="filename"><SystemProperty name="jetty.logs" default="${profile.workdir}/target"/>/yyyy_mm_dd.request.log</Set>
+            <Set name="filenameDateFormat">yyyy_MM_dd</Set>
+            <Set name="retainDays">90</Set>
+            <Set name="append">true</Set>
+            <Set name="extended">false</Set>
+            <Set name="logCookies">false</Set>
+            <Set name="LogTimeZone">GMT</Set>
+            </New>
+        </Set>
+    </Ref>
+</Configure>


### PR DESCRIPTION
Added the ability to launch Entando via Jetty on the port and hostname configured on the profile. Also added Jetty's http request log file. Thanks to the jetty.xml file, developers are more likely to configure some aspects of the container, such as SSL/TLS, log file, etc.