### PR TITLE
Temporary patch for inline editing, fixes the 401 error on REST invocation

### DIFF
--- a/entando-sample/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/aps/jsp/models/inc/content_inline_editing.jsp
+++ b/entando-sample/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/aps/jsp/models/inc/content_inline_editing.jsp
@@ -23,6 +23,9 @@
                         contentType: 'application/json',
                         beforeSend: function (xhr) {
                             var accessToken = window.localStorage.getItem("accessToken");
+                            if (!accessToken) {
+                                accessToken = '<c:out value="${sessionScope.currentUser.accessToken}"/>';
+                            }
                             xhr.setRequestHeader("Authorization", "Bearer " + accessToken);
 
                         }
@@ -53,6 +56,9 @@
                         contentType: 'application/json',
                         beforeSend: function (xhr) {
                             var accessToken = window.localStorage.getItem("accessToken");
+                            if (!accessToken) {
+                                accessToken = '<c:out value="${sessionScope.currentUser.accessToken}"/>';
+                            }
                             xhr.setRequestHeader("Authorization", "Bearer " + accessToken);
 
                         }
@@ -79,6 +85,9 @@
                         contentType: 'application/json',
                         beforeSend: function (xhr) {
                             var accessToken = window.localStorage.getItem("accessToken");
+                            if (!accessToken) {
+                                accessToken = '<c:out value="${sessionScope.currentUser.accessToken}"/>';
+                            }
                             xhr.setRequestHeader("Authorization", "Bearer " + accessToken);
 
                         }
@@ -109,6 +118,9 @@
                         contentType: 'application/json',
                         beforeSend: function (xhr) {
                             var accessToken = window.localStorage.getItem("accessToken");
+                            if (!accessToken) {
+                                accessToken = '<c:out value="${sessionScope.currentUser.accessToken}"/>';
+                            }
                             xhr.setRequestHeader("Authorization", "Bearer " + accessToken);
 
                         }


### PR DESCRIPTION
**THIS PR IS NOT MEANT TO BE MERGED**

This fixes the authentication error when using inline editing.

The Access Token for what I've seen should come from the cookie, but this is not happening; so I'm taking it form the user object in the session.

As a side note, is there a specific reason the modified file is not in the core? 

This file is also present in 

- web-app-generic
- web-app-bpm
